### PR TITLE
Support for icqmail.com accounts

### DIFF
--- a/src/chartable.py
+++ b/src/chartable.py
@@ -3,7 +3,7 @@
 import re
 
 mail_pattern = re.compile(
-	'[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,15}@(mail\.ru|inbox\.ru|bk\.ru|list\.ru|corp\.mail\.ru)$'
+	'[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,15}@(mail\.ru|inbox\.ru|bk\.ru|list\.ru|icqmail\.com|corp\.mail\.ru)$'
 )
 password_pattern = re.compile('[\040-\176]{4,}$')
 number_pattern = re.compile('\+{0,1}[0-9]+$')

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -11,7 +11,7 @@ NOT_REGISTERED = "Вы не зарегистрированы на сервисе
 SEARCH = "Поиск"
 SEARCH_INSTRUCTION = "Заполните поля для поиска. Используйте звёздочку (*) для поиска по шаблону. \
 ВНИМАНИЕ: Вы не можете комбинировать e-mail с другими полями."
-SEARCH_NOTES = "Примечание: поиск ведётся только по адресам доменов @mail.ru, @list.ru, @bk.ru, @inbox.ru."
+SEARCH_NOTES = "Примечание: поиск ведётся только по адресам доменов @mail.ru, @list.ru, @bk.ru, @inbox.ru, @icqmail.com."
 SEARCH_NICK = "Ник"
 SEARCH_NAME = "Имя"
 SEARCH_LASTNAME = "Фамилия"

--- a/src/utils.py
+++ b/src/utils.py
@@ -53,7 +53,7 @@ server_features = common_features + [
 	xmpp.NS_PING]
 
 mail_pattern = re.compile(
-	'[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,35}@(mail\.ru|inbox\.ru|bk\.ru|list\.ru|corp\.mail\.ru|chat\.agent|uin\.icq|aol\.com)$'
+	'[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,35}@(mail\.ru|inbox\.ru|bk\.ru|list\.ru|icqmail\.com|corp\.mail\.ru|chat\.agent|uin\.icq|aol\.com)$'
 )
 password_pattern = re.compile('[\040-\176]{4,}$')
 number_pattern = re.compile('\+{0,1}[0-9]+$')


### PR DESCRIPTION
I haven't tested this, but it appears that MRIM handles icqmail.com accounts just like any other account. I just did a grep to check where the different domains are mentioned and added the entry for icqmail.com.
This should at least enable messaging to others with icqmail.com accounts, but I expect logging on to icqmail.com accounts will work as well.
